### PR TITLE
Use proper Rails log path on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ end
 Monitor your logs with this command:
 
 ```bash
-tail -f -n 1000 logs/development.log | lucy
+tail -f -n 1000 log/development.log | lucy
 ```
 
 ## Development
@@ -40,5 +40,5 @@ LUCY_DEV=1 cargo run
 Or when using the installed binary:
 
 ```bash
-tail -f -n 1000 logs/development.log | LUCY_DEV=1 lucy
+tail -f -n 1000 log/development.log | LUCY_DEV=1 lucy
 ```


### PR DESCRIPTION
`logs/development.log` is not the standard log path for Rails, so it has been changed to `log/development.log`