### PR TITLE
feat: show focused panel in fullscreen during copy mode

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -26,20 +26,41 @@ impl App {
     }
 
     pub fn render(&mut self, f: &mut ratatui::Frame) {
-        self.app_view.layout_info = crate::layout::calculate_layout(f.area());
+        if self.copy_mode_enabled {
+            let focused = self.app_view.focused_panel;
+            self.app_view.layout_info =
+                crate::layout::calculate_single_panel_layout(f.area(), focused);
+            let region = self.app_view.layout_info.region(focused);
+            match focused {
+                Panel::RequestList => {
+                    let widget = panel_components::build_list_component(self);
+                    f.render_widget(widget, region);
+                }
+                Panel::RequestDetail => {
+                    let widget = panel_components::build_detail_component(self);
+                    f.render_widget(widget, region);
+                }
+                Panel::SqlInfo => {
+                    let widget = panel_components::build_sql_component(self);
+                    f.render_widget(widget, region);
+                }
+            }
+        } else {
+            self.app_view.layout_info = crate::layout::calculate_layout(f.area());
 
-        let request_list_region = self.app_view.layout_info.region(Panel::RequestList);
-        let request_detail_region = self.app_view.layout_info.region(Panel::RequestDetail);
-        let sql_info_region = self.app_view.layout_info.region(Panel::SqlInfo);
+            let request_list_region = self.app_view.layout_info.region(Panel::RequestList);
+            let request_detail_region = self.app_view.layout_info.region(Panel::RequestDetail);
+            let sql_info_region = self.app_view.layout_info.region(Panel::SqlInfo);
 
-        let request_list = panel_components::build_list_component(self);
-        f.render_widget(request_list, request_list_region);
+            let request_list = panel_components::build_list_component(self);
+            f.render_widget(request_list, request_list_region);
 
-        let detail_panel = panel_components::build_detail_component(self);
-        f.render_widget(detail_panel, request_detail_region);
+            let detail_panel = panel_components::build_detail_component(self);
+            f.render_widget(detail_panel, request_detail_region);
 
-        let sql_panel = panel_components::build_sql_component(self);
-        f.render_widget(sql_panel, sql_info_region);
+            let sql_panel = panel_components::build_sql_component(self);
+            f.render_widget(sql_panel, sql_info_region);
+        }
     }
 
     pub fn run<B: ratatui::backend::Backend>(

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -53,6 +53,10 @@ pub fn calculate_layout(area: Rect) -> LayoutInfo {
         .with_region(Panel::SqlInfo, top_chunks[2])
 }
 
+pub fn calculate_single_panel_layout(area: Rect, panel: Panel) -> LayoutInfo {
+    LayoutInfo::new().with_region(panel, area)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -88,7 +92,7 @@ mod tests {
         assert_eq!(request_list.y, 0);
         assert_eq!(request_detail.y, 0);
 
-        assert!(sql_info.y > request_detail.y);
+        assert_eq!(sql_info.y, request_detail.y);
 
         // RequestList should be to the left of RequestDetail
         assert!(request_list.x < request_detail.x);

--- a/src/panel_components.rs
+++ b/src/panel_components.rs
@@ -88,9 +88,15 @@ pub fn build_list_component(app: &App) -> List<'_> {
         _ => THEME.default.style(),
     };
 
+    let borders = if app.copy_mode_enabled {
+        Borders::TOP | Borders::BOTTOM
+    } else {
+        Borders::ALL
+    };
+
     List::new(items).block(
         Block::default()
-            .borders(Borders::ALL)
+            .borders(borders)
             .border_type(BorderType::Rounded)
             .border_style(border_style)
             .padding(Padding::new(1, 1, 1, 1))
@@ -227,6 +233,12 @@ pub fn build_detail_component(app: &App) -> Paragraph<'_> {
     };
 
     let title_style = status.to_color().style_with_modifier(Modifier::BOLD);
+    let borders = if app.copy_mode_enabled {
+        Borders::TOP | Borders::BOTTOM
+    } else {
+        Borders::ALL
+    };
+
     let block = Block::default()
         .padding(Padding::new(1, 1, 1, 1))
         .title_alignment(ratatui::layout::Alignment::Left)
@@ -238,7 +250,7 @@ pub fn build_detail_component(app: &App) -> Paragraph<'_> {
             )])
             .alignment(ratatui::layout::Alignment::Right),
         )
-        .borders(Borders::ALL)
+        .borders(borders)
         .border_style(border_style);
 
     if app.simple_mode_enabled {
@@ -248,13 +260,19 @@ pub fn build_detail_component(app: &App) -> Paragraph<'_> {
     }
 }
 
-fn help_text(app: &App) -> &str {
+fn help_text(app: &App) -> String {
     if app.copy_mode_enabled {
-        " COPY MODE (press 'm' to exit) "
-    } else if app.simple_mode_enabled {
-        " SIMPLE MODE (press 's' to exit) | j/k | Tab/Shift+Tab | Ctrl+c | m: copy "
+        let panel_name = match app.app_view.focused_panel {
+            Panel::RequestList => "RequestList",
+            Panel::RequestDetail => "RequestDetail",
+            Panel::SqlInfo => "SqlInfo",
+        };
+        return format!(" COPY MODE [{}] (Tab: switch panel | m: exit) ", panel_name);
+    }
+    if app.simple_mode_enabled {
+        " SIMPLE MODE (press 's' to exit) | j/k | Tab/Shift+Tab | Ctrl+c | m: copy ".to_string()
     } else {
-        " j/k | Ctrl+d/u | Tab/Shift+Tab | Ctrl+c | m: copy | s: simple"
+        " j/k | Ctrl+d/u | Tab/Shift+Tab | Ctrl+c | m: copy | s: simple".to_string()
     }
 }
 
@@ -317,9 +335,15 @@ pub fn build_sql_component(app: &App) -> Paragraph<'_> {
         "0/0".to_string()
     };
 
+    let borders = if app.copy_mode_enabled {
+        Borders::TOP | Borders::BOTTOM
+    } else {
+        Borders::ALL
+    };
+
     let title_text = format!("[{}] ", scroll_info);
     let block = Block::default()
-        .borders(Borders::ALL)
+        .borders(borders)
         .border_style(border_style)
         .padding(Padding::new(1, 1, 0, 0))
         .title(title_text);


### PR DESCRIPTION
Change the settings so that only the focused panel is displayed in full screen during copy mode.