### PR TITLE
perf: reduce unnecessary allocations and clones

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -206,7 +206,7 @@ impl App {
 
     fn get_max_request_list_scroll(&self) -> usize {
         self.state
-            .request_ids()
+            .request_ids
             .len()
             .saturating_sub(self.app_view.viewport_height(Panel::RequestList))
     }
@@ -297,7 +297,7 @@ impl App {
                         let current_offset = self.app_view.get_scroll_offset(Panel::RequestList);
                         let clicked_index = current_offset + row_in_list as usize;
 
-                        if clicked_index < self.state.request_ids().len() {
+                        if clicked_index < self.state.request_ids.len() {
                             self.select_request(clicked_index);
                         }
                     }

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -38,7 +38,7 @@ pub struct LogGroup {
 }
 
 impl LogGroup {
-    pub fn new(log_entry: &LogEntry) -> Self {
+    pub fn new(log_entry: LogEntry) -> Self {
         let mut group = Self {
             title: "...".to_string(),
             entries: VecDeque::with_capacity(10),
@@ -48,7 +48,7 @@ impl LogGroup {
             first_timestamp: log_entry.timestamp,
         };
 
-        group.add_entry(log_entry.clone());
+        group.add_entry(log_entry);
         group
     }
 
@@ -106,15 +106,8 @@ impl AppState {
         }
     }
 
-    pub fn request_ids(&self) -> Vec<&String> {
-        self.request_ids.iter().collect()
-    }
-
     pub fn selected_request_id(&self) -> Option<&String> {
-        match self.request_ids().get(self.selected_index) {
-            Some(id) => Some(*id),
-            None => None,
-        }
+        self.request_ids.get(self.selected_index)
     }
 
     pub fn log_group_count(&self) -> usize {
@@ -127,7 +120,7 @@ impl AppState {
     }
 
     pub fn select_request(&mut self, index: usize) -> bool {
-        if index < self.request_ids().len() {
+        if index < self.request_ids.len() {
             self.selected_index = index;
             true
         } else {
@@ -136,15 +129,15 @@ impl AppState {
     }
 
     pub fn next_request(&mut self, n: usize) -> bool {
-        if self.request_ids().is_empty() || n == 0 {
+        if self.request_ids.is_empty() || n == 0 {
             return false;
         }
-        let new_index = (self.selected_index + n).min(self.request_ids().len() - 1);
+        let new_index = (self.selected_index + n).min(self.request_ids.len() - 1);
         self.select_request(new_index)
     }
 
     pub fn previous_request(&mut self, n: usize) -> bool {
-        if self.request_ids().is_empty() || n == 0 {
+        if self.request_ids.is_empty() || n == 0 {
             return false;
         }
         let new_index = self.selected_index.saturating_sub(n);
@@ -161,27 +154,29 @@ impl AppState {
     }
 
     pub fn add_log_entry(&mut self, log_entry: LogEntry) -> bool {
-        self.all_logs.push(log_entry.clone());
-
         if log_entry.request_id.is_empty() {
+            self.all_logs.push(log_entry);
             return false;
         }
 
-        let request_id = log_entry.request_id.clone();
-        let is_new_request = !self.logs_by_request_id.contains_key(&request_id);
+        let is_new_request = !self.logs_by_request_id.contains_key(&log_entry.request_id);
 
         if is_new_request {
-            let new_group = LogGroup::new(&log_entry);
-            self.logs_by_request_id
-                .insert(request_id.clone(), new_group);
+            let request_id = log_entry.request_id.clone();
+            self.all_logs.push(log_entry.clone());
+            let new_group = LogGroup::new(log_entry);
+            self.request_ids.insert(0, request_id.clone());
+            self.logs_by_request_id.insert(request_id, new_group);
 
-            self.request_ids.insert(0, request_id);
             // 新しいリクエストが追加された場合、選択中のインデックスをずらす
             if self.selected_index > 0 || self.request_ids.len() > 1 {
                 self.selected_index = self.selected_index.saturating_add(1);
             }
-        } else if let Some(group) = self.logs_by_request_id.get_mut(&request_id) {
+        } else if let Some(group) = self.logs_by_request_id.get_mut(&log_entry.request_id) {
+            self.all_logs.push(log_entry.clone());
             group.add_entry(log_entry);
+        } else {
+            self.all_logs.push(log_entry);
         }
 
         is_new_request
@@ -197,7 +192,7 @@ mod tests {
     fn test_app_state_new() {
         let state = AppState::new();
         assert_eq!(state.selected_index, 0);
-        assert!(state.request_ids().is_empty());
+        assert!(state.request_ids.is_empty());
         assert!(state.logs_by_request_id.is_empty());
         assert!(state.request_ids.is_empty());
         assert!(state.all_logs.is_empty());
@@ -239,8 +234,8 @@ mod tests {
 
         let is_new = state.add_log_entry(log_entry);
         assert!(is_new);
-        assert_eq!(state.request_ids().len(), 1);
-        assert_eq!(state.request_ids()[0], "req-1");
+        assert_eq!(state.request_ids.len(), 1);
+        assert_eq!(state.request_ids[0], "req-1");
         assert_eq!(state.all_logs.len(), 1);
         assert_eq!(state.selected_index, 0);
 
@@ -253,7 +248,7 @@ mod tests {
 
         let is_new2 = state.add_log_entry(log_entry2);
         assert!(!is_new2);
-        assert_eq!(state.request_ids().len(), 1);
+        assert_eq!(state.request_ids.len(), 1);
         assert_eq!(state.all_logs.len(), 2);
         assert_eq!(state.selected_index, 0);
 
@@ -266,9 +261,9 @@ mod tests {
 
         let is_new3 = state.add_log_entry(log_entry3);
         assert!(is_new3);
-        assert_eq!(state.request_ids().len(), 2);
-        assert_eq!(state.request_ids()[0], "req-2");
-        assert_eq!(state.request_ids()[1], "req-1");
+        assert_eq!(state.request_ids.len(), 2);
+        assert_eq!(state.request_ids[0], "req-2");
+        assert_eq!(state.request_ids[1], "req-1");
         assert_eq!(state.all_logs.len(), 3);
         assert_eq!(state.selected_index, 1);
     }
@@ -325,13 +320,13 @@ mod tests {
             state.add_log_entry(log_entry);
         }
 
-        assert_eq!(state.request_ids()[0], "req-1");
-        assert_eq!(state.request_ids()[1], "req-2");
-        assert_eq!(state.request_ids()[2], "req-3");
+        assert_eq!(state.request_ids[0], "req-1");
+        assert_eq!(state.request_ids[1], "req-2");
+        assert_eq!(state.request_ids[2], "req-3");
 
-        let ids = state.request_ids();
-        assert_eq!(*ids[0], "req-1");
-        assert_eq!(*ids[1], "req-2");
-        assert_eq!(*ids[2], "req-3");
+        let ids = &state.request_ids;
+        assert_eq!(ids[0], "req-1");
+        assert_eq!(ids[1], "req-2");
+        assert_eq!(ids[2], "req-3");
     }
 }

--- a/src/panel_components.rs
+++ b/src/panel_components.rs
@@ -27,13 +27,11 @@ pub fn build_list_component(app: &App) -> List<'_> {
             break;
         }
 
-        let request_id = app.state.request_ids()[index];
+        let request_id = &app.state.request_ids[index];
         let group = app.state.logs_by_request_id.get(request_id).unwrap();
         let time_str = group.first_timestamp.format("%H:%M:%S").to_string();
 
         let finished = group.finished;
-        let title = group.title.clone();
-
         let log_count = group.entries.len();
         let sql_count = group.sql_query_info.total_queries();
 
@@ -54,7 +52,7 @@ pub fn build_list_component(app: &App) -> List<'_> {
                 format!("{:2}-{:2} ", log_count, sql_count),
                 THEME.default.style().fg(Color::Cyan),
             ),
-            Span::styled(title, status_color),
+            Span::styled(group.title.as_str(), status_color),
         ]);
 
         let style = if index == app.state.selected_index {
@@ -136,7 +134,7 @@ pub fn build_detail_component(app: &App) -> Paragraph<'_> {
                     .collect::<String>();
                 Span::raw(text)
             } else {
-                Span::raw("".to_string())
+                Span::raw("")
             };
 
             let viewport_height = app.app_view.viewport_height(Panel::RequestDetail);
@@ -311,7 +309,7 @@ pub fn build_sql_component(app: &App) -> Paragraph<'_> {
         if total_queries == 0 {
             "0/0".to_string()
         } else {
-            format!("{}", total_queries)
+            total_queries.to_string()
         }
     } else {
         "0/0".to_string()

--- a/src/simple_formatter.rs
+++ b/src/simple_formatter.rs
@@ -52,9 +52,9 @@ pub fn format_simple_log_line(line: &str) -> Option<Line<'static>> {
 
 pub fn parse_ansi_colors(text: &str) -> Vec<Span<'static>> {
     match text.into_text() {
-        Ok(parsed_text) => {
+        Ok(mut parsed_text) => {
             if !parsed_text.lines.is_empty() {
-                parsed_text.lines[0].spans.clone()
+                parsed_text.lines.remove(0).spans
             } else {
                 vec![Span::raw(text.to_string())]
             }

--- a/src/sql_info.rs
+++ b/src/sql_info.rs
@@ -1,4 +1,13 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
 use std::collections::HashMap;
+
+static TABLE_PATTERN: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?:FROM|JOIN|UPDATE|INTO)\s+(?:"([a-zA-Z0-9_]+)"|([a-zA-Z0-9_]+))(?:\s|\)|$)"#,
+    )
+    .unwrap()
+});
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum QueryType {
@@ -74,16 +83,6 @@ impl SqlQueryInfo {
 pub fn parse_sql_from_logs(logs: &[&str]) -> SqlQueryInfo {
     let mut sql_info = SqlQueryInfo::new();
 
-    let table_pattern = match regex::Regex::new(
-        r#"(?:FROM|JOIN|UPDATE|INTO)\s+(?:"([a-zA-Z0-9_]+)"|([a-zA-Z0-9_]+))(?:\s|\)|$)"#,
-    ) {
-        Ok(re) => re,
-        Err(e) => {
-            eprintln!("Regex error: {}", e);
-            regex::Regex::new(r"").unwrap()
-        }
-    };
-
     for msg in logs {
         let query_type = if msg.contains("SELECT ") {
             Some(QueryType::Select)
@@ -99,7 +98,7 @@ pub fn parse_sql_from_logs(logs: &[&str]) -> SqlQueryInfo {
 
         if let Some(query_type) = query_type {
             *sql_info.query_counts.entry(query_type).or_insert(0) += 1;
-            for cap in table_pattern.captures_iter(msg) {
+            for cap in TABLE_PATTERN.captures_iter(msg) {
                 let table_name = cap.get(1).or_else(|| cap.get(2)).map(|m| m.as_str());
 
                 if let Some(table_name) = table_name {


### PR DESCRIPTION
不要なアロケーション・cloneを削減してパフォーマンスを改善。

- `sql_info.rs`: Regexを毎回コンパイルしていたのを`Lazy`staticに変更（ログエントリごとのO(n)コンパイルを排除）
- `app_state.rs`: `request_ids()`メソッドが毎回`Vec<&String>`をアロケーションしていたのを、フィールド直接参照に変更
- `app_state.rs`: `LogGroup::new()`を値渡しに変更し、内部の不要なcloneを排除
- `app_state.rs`: `add_log_entry()`のclone回数を2-3回から1回に削減
- `simple_formatter.rs`: `parse_ansi_colors()`でspans Vecのcloneを`remove(0)`による移動に変更
- `panel_components.rs`: レンダーループ内の`title.clone()`を`as_str()`に変更
- `panel_components.rs`: `Span::raw("".to_string())`→`Span::raw("")`
- `panel_components.rs`: `format!("{}", x)`→`x.to_string()`